### PR TITLE
Fix missing parenthesis for returning object

### DIFF
--- a/additional-feature-ts.md
+++ b/additional-feature-ts.md
@@ -241,7 +241,7 @@ value
 |> f
 |> {
   try |> JSON.parse;
-  catch |> { message: #.message };
+  catch |> ({ message: #.message });
 }
 |> g(#, 1);
 ```


### PR DESCRIPTION
As the core proposal specifies, returning an object in a pipeline needs to be surrounded with parenthesis, to ensure forward compatibility with [Additional Feature BP](https://github.com/js-choi/proposal-smart-pipelines/blob/master/additional-feature-bp.md).